### PR TITLE
showing bot command while using help solved 

### DIFF
--- a/commands/help.py
+++ b/commands/help.py
@@ -2,7 +2,6 @@ from telegram import ParseMode, InlineKeyboardButton, InlineKeyboardMarkup
 import os
 
 bot_name = os.getenv("bot_name")
-bot_name.replace("_","\\_")
 
 def help(update, context):
     help_text = (

--- a/commands/help.py
+++ b/commands/help.py
@@ -2,6 +2,7 @@ from telegram import ParseMode, InlineKeyboardButton, InlineKeyboardMarkup
 import os
 
 bot_name = os.getenv("bot_name")
+bot_name.replace("_","\\_")
 
 def help(update, context):
     help_text = (
@@ -21,7 +22,7 @@ def help(update, context):
     context.bot.send_message(
         chat_id=chat_id,
         text=help_text,
-        parse_mode=ParseMode.MARKDOWN,
+        parse_mode=ParseMode.HTML,
         disable_web_page_preview=True,
         reply_markup=url_reply_markup
     )


### PR DESCRIPTION
## Description
### help.py
 to sove markdown of  ```_``` i used replace and replaced it with ```\_```.
and  instead of ParseMode.MARKDOWN i have used ParseMode.HTML,

## Does this resolve any currently open issues?
Resolves #20 

## Screenshot/GIF showing resolved bug/enhancement (if applicable)
..
![image](https://user-images.githubusercontent.com/67951999/131353142-5c151f0c-7724-40a7-9e84-3d9b28535f0f.png)


